### PR TITLE
Add: Missing comma for who copies the example

### DIFF
--- a/src/v0.15/guide/getting-started.md
+++ b/src/v0.15/guide/getting-started.md
@@ -99,7 +99,7 @@ const theMoon = {
 };
 
 store.update(t => [
-  t.addRecord(venus)
+  t.addRecord(venus),
   t.addRecord(earth),
   t.addRecord(theMoon)
 ])


### PR DESCRIPTION
I only edited line 102, I'm not sure why it shows an edit for 464, must be the online editor. Seems like I should not use this anymore, even for simple things. 🙃