### PR TITLE
Clarify task processing methods live on queue

### DIFF
--- a/src/v0.16/guide/task-processing.md
+++ b/src/v0.16/guide/task-processing.md
@@ -94,7 +94,8 @@ Queues emit the following events when processing tasks:
 As each task is processed successfully, it will be removed from the queue.
 
 If processing fails, the queue will emit the `fail` event and processing will
-stop. At that point, you have several options:
+stop. At that point, there are several different methods on the queue you can
+call, depending on how you want to respond to the failure:
 
 - `retry()` will retry the task that failed.
 


### PR DESCRIPTION
When trying to handle task failure, I read the Task Processing > Task Queues > Task Processing section of the guides, but I wasn't clear on the fact that the methods listed existed on the queue. While I was troubleshooting something that was going wrong, this uncertainty made me question whether maybe the methods were on the task, some other object, or didn't exist at all anymore.

This PR adds a small clarification to say that the functions listed are methods on the queue. This might help prevent others getting confused, and increase their confidence.