### PR TITLE
Update attribute types to include object, array and unknown

### DIFF
--- a/src/v0.16/guide/modeling-data.md
+++ b/src/v0.16/guide/modeling-data.md
@@ -161,9 +161,16 @@ should be serialized. Valid attribute types are:
 
 - `boolean`
 - `date`
-- `date-time`
+- `datetime`
 - `number`
 - `string`
+
+The following attribute types are passed through as-is and no special
+serialization is performed:
+
+- `object`
+- `array`
+- `unknown`
 
 ### Model relationships
 


### PR DESCRIPTION
Per the changes in https://github.com/orbitjs/orbit/pull/783 that did not have a corresponding edit to docs.

Also it appears `date-time` should be `datetime`.